### PR TITLE
Custom configuration to add mongoDB connection options attribute

### DIFF
--- a/lib/checks/mongo.js
+++ b/lib/checks/mongo.js
@@ -6,14 +6,14 @@ const Check = require('../check');
 module.exports = class Mongo extends Check {
     constructor(config) {
         super(config);
+        this.options = this.config.options || {};
+        this.options.useNewUrlParser = true;
         this.error = new Error(`MongoDB connection to ${config.url} failed.`);
     }
 
     async start () {
         return await new Promise(resolve => {
-            MongoClient.connect(this.config.url, {
-                useNewUrlParser: true
-            }, (err, db) => {
+            MongoClient.connect(this.config.url, this.options, (err, db) => {
                 if (!err) {
                     this.db = db;
                     this.db.topology


### PR DESCRIPTION
In order to use ssl configuration to connect mongoDB. we need CA file in mongo connect function. That optional setting is impleted in this commit